### PR TITLE
Update nodes when recipes.json changes

### DIFF
--- a/src/state/recipes/actions/loadNodes.ts
+++ b/src/state/recipes/actions/loadNodes.ts
@@ -5,7 +5,12 @@ export const loadNodes: AsyncAction = async ({ state, effects }) => {
     const nodes = effects.loadLocalStorageNodes();
     if (nodes) {
         nodes.forEach(n => {
-            const node = ProductionNode.fromJson(n);
+            const node = ProductionNode.fromJson(n, {
+                recipes: state.recipes.items,
+                machines: state.machines.items,
+                categories: state.categories.items,
+                products: state.products.items,
+            });
             state.recipes.nodes[node.id] = node;
         });
     }


### PR DESCRIPTION
## Summary
- refresh ProductionNode data from current JSON when loading from storage
- load nodes with latest recipe, machine, category and product info

## Testing
- `CI=true yarn test --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68441a22d2f4832f863bf88eaeda8682